### PR TITLE
Use thread handler instead of callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ axum = ["dep:axum"]
 actix-web = { version = "4", optional = true}
 actix-web-httpauth = { version = "0.8.0", optional = true }
 axum = { version = "0.6", optional = true }
-tokio = { version = "1.20", features = ["macros", "rt"] }
+tokio = { version = "1.20", features = ["macros", "rt", "rt-multi-thread"] }
 futures = "0.3"
 tracing = "0.1"
 jsonwebtoken = "8.1.1"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ async fn greet(user: FirebaseUser) -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Create an application state for `FirebaseAuth` that will automatically refresh the public keys.
-    // Change the project_id to your Firebase Project ID.
-    // We put this in blocking because the first time it runs, it will try to retrieve the public keys
-    // from the Google endpoint. If it fails, it will panic.
-    let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-        .await
-        .expect("panic init FirebaseAuth");
+    let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app_data = Data::new(firebase_auth);
 
@@ -84,9 +78,7 @@ async fn public() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-        .await
-        .expect("panic init FirebaseAuth");
+    let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app = Router::new()
         .route("/hello", get(greeting))

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ async fn main() -> std::io::Result<()> {
 use axum::{routing::get, Router};
 use firebase_auth::{FirebaseAuth, FirebaseAuthState, FirebaseUser};
 
-async fn greeting(current_user: FirebaseUser) -> String {
+async fn greet(current_user: FirebaseUser) -> String {
     let email = current_user.email.unwrap_or("empty email".to_string());
     format!("hello {}", email)
 }
@@ -81,7 +81,7 @@ async fn main() {
     let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app = Router::new()
-        .route("/hello", get(greeting))
+        .route("/hello", get(greet))
         .route("/", get(public))
         .with_state(FirebaseAuthState { firebase_auth });
 

--- a/examples/actix_basic.rs
+++ b/examples/actix_basic.rs
@@ -19,13 +19,7 @@ async fn public() -> impl Responder {
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(Env::default().default_filter_or("debug"));
 
-    // Create Application State for the `FirebaseAuth` it will refresh the public keys
-    // automatically.
-    // We put this in blocking because the first time it run, it will try to get the public keys
-    // from Google endpoint, if it failed it will panic.
-    let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-        .await
-        .expect("panic init FirebaseAuth");
+    let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app_data = Data::new(firebase_auth);
 

--- a/examples/actix_basic.rs
+++ b/examples/actix_basic.rs
@@ -2,8 +2,6 @@ use actix_web::{get, middleware::Logger, web::Data, App, HttpServer, Responder};
 use env_logger::Env;
 use firebase_auth::{FirebaseAuth, FirebaseUser};
 
-// Use `FirebaseUser` extractor to verify the user token and decode the claims
-
 #[get("/hello")]
 async fn greet(user: FirebaseUser) -> impl Responder {
     let email = user.email.unwrap_or("empty email".to_string());

--- a/examples/axum_basic.rs
+++ b/examples/axum_basic.rs
@@ -12,9 +12,7 @@ async fn public() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-        .await
-        .expect("panic init FirebaseAuth");
+    let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app = Router::new()
         .route("/hello", get(greeting))

--- a/examples/axum_basic.rs
+++ b/examples/axum_basic.rs
@@ -1,7 +1,7 @@
 use axum::{routing::get, Router};
 use firebase_auth::{FirebaseAuth, FirebaseAuthState, FirebaseUser};
 
-async fn greeting(user: FirebaseUser) -> String {
+async fn greet(user: FirebaseUser) -> String {
     let email = user.email.unwrap_or("empty email".to_string());
     format!("hello {}", email)
 }
@@ -15,7 +15,7 @@ async fn main() {
     let firebase_auth = FirebaseAuth::new("my-project-id").await;
 
     let app = Router::new()
-        .route("/hello", get(greeting))
+        .route("/hello", get(greet))
         .route("/", get(public))
         .with_state(FirebaseAuthState { firebase_auth });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! use axum::{routing::get, Router};
 //! use firebase_auth::{FirebaseAuth, FirebaseAuthState, FirebaseUser};
 //!
-//! async fn greeting(user: FirebaseUser) -> String {
+//! async fn greet(user: FirebaseUser) -> String {
 //!     let email = user.email.unwrap_or("empty email".to_string());
 //!     format!("hello {}", email)
 //! }
@@ -63,7 +63,7 @@
 //!     let firebase_auth = FirebaseAuth::new("my-project-id").await;
 //!
 //!     let app = Router::new()
-//!         .route("/hello", get(greeting))
+//!         .route("/hello", get(greet))
 //!         .route("/", get(public))
 //!         .with_state(FirebaseAuthState { firebase_auth });
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,7 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     // Create an application state for `FirebaseAuth` that will automatically refresh the public keys.
-//!     // Change the project_id to your Firebase Project ID.
-//!     // We put this in blocking because the first time it runs, it will try to retrieve the public keys
-//!     // from the Google endpoint. If it fails, it will panic.
-//!     let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-//!         .await
-//!         .expect("panic init FirebaseAuth");
+//!     let firebase_auth = FirebaseAuth::new("my-project-id").await;
 //!
 //!     let app_data = Data::new(firebase_auth);
 //!
@@ -66,9 +60,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
-//!         .await
-//!         .expect("panic init FirebaseAuth");
+//!     let firebase_auth = FirebaseAuth::new("my-project-id").await;
 //!
 //!     let app = Router::new()
 //!         .route("/hello", get(greeting))


### PR DESCRIPTION
Improve the intialize process

OLD
```rust
let firebase_auth = tokio::task::spawn_blocking(|| FirebaseAuth::new("my-project-id"))
    .await
    .expect("panic init FirebaseAuth");
```

NEW
```rust
let firebase_auth = FirebaseAuth::new("my-project-id").await;
```