### PR TITLE
accept invalid tokens when firebase emulator env variable is set

### DIFF
--- a/firebase-auth/Cargo.toml
+++ b/firebase-auth/Cargo.toml
@@ -32,3 +32,4 @@ jsonwebtoken = "9.1.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
+base64 = "0.22.1"


### PR DESCRIPTION
https://firebase.google.com/docs/emulator-suite/connect_auth#admin_sdks

The official SDK from firebase implements a check for when an env variable "FIREBASE_AUTH_EMULATOR_HOST" is set, in which case the signature verification is skipped and it just decodes the payload. This is useful for testing purposes when using the firebase emulator, since it does not sign the tokens for security reasons.

I think it would be useful to align with the official SDKs and implement the same.
