### PR TITLE
update axum to 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 ## Notice
 
+Version 0.5.x supports Axum 0.8.
+
 Version 0.4.x supports Axum 0.7.
 
 Version 0.3.x will continue to provide support and fix bugs for Axum 0.6.
@@ -32,7 +34,7 @@ _Axum_
 ```toml
 [dependencies]
 firebase-auth = { version = "<version>", features = ["axum"] }
-axum = "0.7"
+axum = "0.8"
 ```
 
 # Examples

--- a/examples/axum-basic/Cargo.toml
+++ b/examples/axum-basic/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 firebase-auth = { path = "../../firebase-auth" }
-axum = "0.7"
+axum = "0.8"
 tokio = { version = "1.0", features = ["full"] }
 tower-http = { version = "0.5.0", features = ["trace"] }
 tracing = "0.1"

--- a/examples/axum-custom-claims/Cargo.toml
+++ b/examples/axum-custom-claims/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 firebase-auth = { path = "../../firebase-auth" }
-axum = "0.7"
+axum = "0.8"
 tokio = { version = "1.0", features = ["full"] }
 tower-http = { version = "0.5.0", features = ["trace"] }
 tracing = "0.1"

--- a/examples/axum-custom-claims/src/main.rs
+++ b/examples/axum-custom-claims/src/main.rs
@@ -1,5 +1,4 @@
 use axum::{
-    async_trait,
     extract::{FromRef, FromRequestParts},
     http::{self, request::Parts, StatusCode},
     response::{IntoResponse, Response},
@@ -46,7 +45,6 @@ fn get_bearer_token(header: &str) -> Option<String> {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for FirebaseUser
 where
     FirebaseAuthState: FromRef<S>,

--- a/examples/axum-sqlite/Cargo.toml
+++ b/examples/axum-sqlite/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 firebase-auth = { path = "../../firebase-auth" }
-axum = "0.7"
+axum = "0.8"
 axum-macros = "0.4"
 tokio = { version = "1.0", features = ["full"] }
 tower-http = { version = "0.5.0", features = ["trace"] }

--- a/firebase-auth/Cargo.toml
+++ b/firebase-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firebase-auth"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Chop Tr <m@chop.dev>"]
 homepage = "https://github.com/trchopan/firebase-auth"
 repository = "https://github.com/trchopan/firebase-auth.git"
@@ -24,7 +24,7 @@ axum = ["dep:axum"]
 [dependencies]
 actix-web = { version = "4", optional = true }
 actix-web-httpauth = { version = "0.8.0", optional = true }
-axum = { version = "0.7", optional = true }
+axum = { version = "0.8", optional = true }
 tokio = { version = "1.33.0", features = ["macros", "rt", "rt-multi-thread"] }
 futures = "0.3"
 tracing = "0.1"

--- a/firebase-auth/src/axum_feature.rs
+++ b/firebase-auth/src/axum_feature.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use axum::{
-    async_trait,
     extract::{FromRef, FromRequestParts},
     http::{self, request::Parts, StatusCode},
     response::{IntoResponse, Response},
@@ -32,7 +31,6 @@ fn get_bearer_token(header: &str) -> Option<String> {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for FirebaseUser
 where
     FirebaseAuthState: FromRef<S>,

--- a/firebase-auth/src/structs.rs
+++ b/firebase-auth/src/structs.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct JwkConfiguration {
     pub jwk_url: String,
@@ -15,6 +16,7 @@ pub struct KeyResponse {
     pub keys: Vec<JwkKey>,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct JwkKey {
     pub e: String,


### PR DESCRIPTION

- Updated to axum 0.8 ( close #35 )
  -  `firebase-auth` crate itself
  - crates in `examples`
- Added allow dead code for struct that contains unused fields
- Incremented the minor version of `firebase-auth` package `0.4.x` -> `0.5.0`
- Update the README